### PR TITLE
将opsoft改为Opspft,使其他包可以进行访问，便于二次开发

### DIFF
--- a/background.go
+++ b/background.go
@@ -37,7 +37,7 @@ mode 整形数: 模式
 
 整形数: 0:失败 1:成功
 */
-func (com *opsoft) BindWindow(hwnd int, display string, mouse string, keypad string, mode int) int {
+func (com *Opsoft) BindWindow(hwnd int, display string, mouse string, keypad string, mode int) int {
 	ret, _ := com.op.CallMethod("BindWindow", hwnd, display, mouse, keypad, mode)
 	return int(ret.Val)
 }
@@ -51,7 +51,7 @@ func (com *opsoft) BindWindow(hwnd int, display string, mouse string, keypad str
 
 整形数: 0:失败 1:成功
 */
-func (com *opsoft) UnBindWindow() int {
+func (com *Opsoft) UnBindWindow() int {
 	ret, _ := com.op.CallMethod("UnBindWindow")
 	return int(ret.Val)
 }

--- a/base_option.go
+++ b/base_option.go
@@ -9,7 +9,7 @@ package op
 
 字符串: 返回op.dll所在路径
 */
-func (com *opsoft) GetBasePath() string {
+func (com *Opsoft) GetBasePath() string {
 	ret, _ := com.op.CallMethod("GetBasePath")
 	return ret.ToString()
 }
@@ -23,7 +23,7 @@ func (com *opsoft) GetBasePath() string {
 
 整形数: 当前对象的ID值.
 */
-func (com *opsoft) GetID() int {
+func (com *Opsoft) GetID() int {
 	ret, _ := com.op.CallMethod("GetID")
 	return int(ret.Val)
 }
@@ -39,7 +39,7 @@ func (com *opsoft) GetID() int {
 
 注: 此函数必须紧跟上一句函数调用，中间任何的语句调用都会改变这个值.
 */
-func (com *opsoft) GetLastError() int {
+func (com *Opsoft) GetLastError() int {
 	ret, _ := com.op.CallMethod("GetLastError")
 	return int(ret.Val)
 }
@@ -53,7 +53,7 @@ func (com *opsoft) GetLastError() int {
 
 字符串: 以字符串的形式返回当前设置的全局路径
 */
-func (com *opsoft) GetPath() string {
+func (com *Opsoft) GetPath() string {
 	ret, _ := com.op.CallMethod("GetPath")
 	return ret.ToString()
 }
@@ -71,7 +71,7 @@ path 字符串: 路径,可以是相对路径,也可以是绝对路径
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) SetPath(path string) int {
+func (com *Opsoft) SetPath(path string) int {
 	ret, _ := com.op.CallMethod("SetPath", path)
 	return int(ret.Val)
 }
@@ -89,7 +89,7 @@ show 整形数: 0表示不打开,1表示打开，2表示将错误信息写入文
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) SetShowErrorMsg(show int) int {
+func (com *Opsoft) SetShowErrorMsg(show int) int {
 	ret, _ := com.op.CallMethod("SetShowErrorMsg", show)
 	return int(ret.Val)
 }
@@ -103,7 +103,7 @@ func (com *opsoft) SetShowErrorMsg(show int) int {
 
 字符串: 当前插件的版本描述字符串
 */
-func (com *opsoft) Ver() string {
+func (com *Opsoft) Ver() string {
 	ver, _ := com.op.CallMethod("Ver")
 	return ver.ToString()
 }
@@ -123,7 +123,7 @@ enable 整形数: 0 : 关闭 1 : 打开
 
 注: 有些时候，系统内存比较吃紧，这时候再打开内部缓存，可能会导致缓存分配在虚拟内存，这样频繁换页，反而导致图色效率下降.这时候就建议关闭图色缓存. 所有图色缓存机制都是对本对象的，也就是说，调用图色缓存机制的函数仅仅对本对象生效. 每个对象都有一个图色缓存队列.
 */
-func (com *opsoft) EnablePicCache(enable int) int {
+func (com *Opsoft) EnablePicCache(enable int) int {
 	ret, _ := com.op.CallMethod("EnablePicCache", enable)
 	return int(ret.Val)
 }

--- a/image_proc.go
+++ b/image_proc.go
@@ -27,7 +27,7 @@ file string 保存的文件名.
 
 int 0:失败 1:成功
 */
-func (com *opsoft) Capture(x1, y1, x2, y2 int, file string) int {
+func (com *Opsoft) Capture(x1, y1, x2, y2 int, file string) int {
 	ret, _ := com.op.CallMethod("Capture", x1, y1, x2, y2, file)
 	return int(ret.Val)
 }
@@ -51,7 +51,7 @@ sim float 相似度(0.1-1.0)
 
 int: 0: 颜色匹配 1: 颜色不匹配
 */
-func (com *opsoft) CmpColor(x int, y int, color string, sim float32) int {
+func (com *Opsoft) CmpColor(x int, y int, color string, sim float32) int {
 	ret, _ := com.op.CallMethod("CmpColor", x, y, color, sim)
 	return int(ret.Val)
 }
@@ -85,7 +85,7 @@ intY *int 返回Y坐标
 
 int 0:没找到 1:找到
 */
-func (com *opsoft) FindColor(x1, y1, x2, y2 int, color string, sim float32, dir int, intX *int, intY *int) int {
+func (com *Opsoft) FindColor(x1, y1, x2, y2 int, color string, sim float32, dir int, intX *int, intY *int) int {
 	x := ole.NewVariant(ole.VT_I4, 0)
 	y := ole.NewVariant(ole.VT_I4, 0)
 	ret, _ := com.op.CallMethod("FindColor", x1, y1, x2, y2, color, sim, dir, &x, &y)
@@ -119,7 +119,7 @@ dir int 查找方向 0: 从左到右,从上到下 1: 从左到右,从下到上 2
 
 string 返回所有颜色信息的坐标值,然后通过GetResultCount等接口来解析 (由于内存限制,返回的颜色数量最多为1800个左右)
 */
-func (com *opsoft) FindColorEx(x1, y1, x2, y2 int, color string, sim float32, dir int) string {
+func (com *Opsoft) FindColorEx(x1, y1, x2, y2 int, color string, sim float32, dir int) string {
 	ret, _ := com.op.CallMethod("FindColorEx", x1, y1, x2, y2, color, sim, dir)
 	return ret.ToString()
 }
@@ -163,7 +163,7 @@ intY 变参指针:返回Y坐标(坐标为first_color所在坐标)
 
 整形数: 0:没找到 1:找到
 */
-func (com *opsoft) FindMultiColor(x1, y1, x2, y2 int, firstColor string, offsetColor string, sim float32, dir int, intX, intY *int) int {
+func (com *Opsoft) FindMultiColor(x1, y1, x2, y2 int, firstColor string, offsetColor string, sim float32, dir int, intX, intY *int) int {
 	x := ole.NewVariant(ole.VT_I4, 0)
 	y := ole.NewVariant(ole.VT_I4, 0)
 	ret, _ := com.op.CallMethod("FindMultiColor", x1, y1, x2, y2, firstColor, offsetColor, sim, dir, &x, &y)
@@ -211,7 +211,7 @@ sim 双精度浮点数:相似度,取值范围0.1-1.0 dir 整形数:查找方向 
 
 坐标是first_color所在的坐标
 */
-func (com *opsoft) FindMultiColorEx(x1, y1, x2, y2 int, firstColor string, offsetColor string, sim float32, dir int) string {
+func (com *Opsoft) FindMultiColorEx(x1, y1, x2, y2 int, firstColor string, offsetColor string, sim float32, dir int) string {
 	ret, _ := com.op.CallMethod("FindMultiColorEx", x1, y1, x2, y2, firstColor, offsetColor, sim, dir)
 	return ret.ToString()
 }
@@ -249,7 +249,7 @@ intY 变参指针:返回图片左上角的Y坐标
 
 整形数: 返回找到的图片的序号,从0开始索引.如果没找到返回-1
 */
-func (com *opsoft) FindPic(x1, y1, x2, y2 int, picName string, deltaColor string, sim float32, dir int, intX, intY *int) int {
+func (com *Opsoft) FindPic(x1, y1, x2, y2 int, picName string, deltaColor string, sim float32, dir int, intX, intY *int) int {
 	x := ole.NewVariant(ole.VT_I4, 0)
 	y := ole.NewVariant(ole.VT_I4, 0)
 	ret, _ := com.op.CallMethod("FindPic", x1, y1, x2, y2, picName, deltaColor, sim, dir, &x, &y)
@@ -291,7 +291,7 @@ dir 整形数:查找方向 0: 从左到右,从上到下 1: 从左到右,从下�
 
 比如"0,100,20|2,30,40" 表示找到了两个,第一个,对应的图片是图像序号为0的图片,坐标是(100,20),第二个是序号为2的图片,坐标(30,40) (由于内存限制,返回的图片数量最多为1500个左右)
 */
-func (com *opsoft) FindPicEx(x1, y1, x2, y2 int, picName string, deltaColor string, sim float32, dir int) string {
+func (com *Opsoft) FindPicEx(x1, y1, x2, y2 int, picName string, deltaColor string, sim float32, dir int) string {
 	ret, _ := com.op.CallMethod("FindPicEx", x1, y1, x2, y2, picName, deltaColor, sim, dir)
 	return ret.ToString()
 }
@@ -313,7 +313,7 @@ y 整形数:Y坐标
 
 比如"0,100,20|2,30,40" 表示找到了两个,第一个,对应的图片是图像序号为0的图片,坐标是(100,20),第二个是序号为2的图片,坐标(30,40) (由于内存限制,返回的图片数量最多为1500个左右)
 */
-func (com *opsoft) EnableGetColorByCapture(enable int) int {
+func (com *Opsoft) EnableGetColorByCapture(enable int) int {
 	ret, _ := com.op.CallMethod("EnableGetColorByCapture", enable)
 	return int(ret.Val)
 }
@@ -331,7 +331,7 @@ file 字符串:保存的文件名,保存的地方一般为SetPath中设置的目
 
 整形数: 0:失败 1:成功
 */
-func (com *opsoft) CapturePre(file string) int {
+func (com *Opsoft) CapturePre(file string) int {
 	ret, _ := com.op.CallMethod("CapturePre", file)
 	return int(ret.Val)
 }
@@ -349,7 +349,7 @@ enable_debug 整形数: 0 为关闭 1 为开启
 
 整形数: 0:失败 1:成功
 */
-func (com *opsoft) EnableDisplayDebug(enableDebug int) int {
+func (com *Opsoft) EnableDisplayDebug(enableDebug int) int {
 	ret, _ := com.op.CallMethod("EnableDisplayDebug", enableDebug)
 	return int(ret.Val)
 }
@@ -373,7 +373,7 @@ y2 整形数:区域的右下Y坐标
 
 整形数: 返回的是指定区域的二进制颜色数据地址,每个颜色是4个字节,表示方式为(BBGGRR00)
 */
-func (com *opsoft) GetScreenData(x1, y1, x2, y2 int) int {
+func (com *Opsoft) GetScreenData(x1, y1, x2, y2 int) int {
 	ret, _ := com.op.CallMethod("GetScreenData", x1, y1, x2, y2)
 	return int(ret.Val)
 }
@@ -401,7 +401,7 @@ size 变参指针:返回图片的数据长度
 
 整形数: 0 : 失败 1 : 成功
 */
-func (com *opsoft) GetScreenDataBmp(x1, y1, x2, y2 int, data, size *int) int {
+func (com *Opsoft) GetScreenDataBmp(x1, y1, x2, y2 int, data, size *int) int {
 	d := ole.NewVariant(ole.VT_I4, 0)
 	s := ole.NewVariant(ole.VT_I4, 0)
 	ret, _ := com.op.CallMethod("GetScreenDataBmp", x1, y1, x2, y2, &data, &size)
@@ -434,7 +434,7 @@ mode 字符串: 图色输入模式取值有以下几种
 
 整形数: 0 : 失败 1 : 成功
 */
-func (com *opsoft) SetDisplayInput(mode string) int {
+func (com *Opsoft) SetDisplayInput(mode string) int {
 	ret, _ := com.op.CallMethod("SetDisplayInput", mode)
 	return int(ret.Val)
 }

--- a/keyboard_mouse.go
+++ b/keyboard_mouse.go
@@ -13,7 +13,7 @@ y int类型 返回Y坐标
 返回值:
 
 int类型 0失败，1成功 */
-func (com *opsoft) GetCursorPos(x, y *int) int {
+func (com *Opsoft) GetCursorPos(x, y *int) int {
 	intx := ole.NewVariant(ole.VT_I4, int64(*x))
 	inty := ole.NewVariant(ole.VT_I4, int64(*y))
 	ret, _ := com.op.CallMethod("GetCursorPos", &intx, &inty)
@@ -35,7 +35,7 @@ vk int类型 虚拟按键码
 
 int类型 0弹起，1按下
 */
-func (com *opsoft) GetKeyState(vk_code int) int {
+func (com *Opsoft) GetKeyState(vk_code int) int {
 	ret, _ := com.op.CallMethod("GetKeyState", vk_code)
 	return int(ret.Val)
 }
@@ -51,7 +51,7 @@ vk_code int 虚拟按键码
 
 int类型 0成功，1失败
 */
-func (com *opsoft) KeyDown(vk_code string) int {
+func (com *Opsoft) KeyDown(vk_code string) int {
 	ret, _ := com.op.CallMethod("KeyDown", vk_code)
 	return int(ret.Val)
 }
@@ -67,7 +67,7 @@ key_str string 字符串描述的键码. 大小写无所谓.
 
 int类型 0成功，1失败
 */
-func (com *opsoft) KeyDownChar(key_str string) int {
+func (com *Opsoft) KeyDownChar(key_str string) int {
 	ret, _ := com.op.CallMethod("KeyDownChar", key_str)
 	return int(ret.Val)
 }
@@ -83,7 +83,7 @@ vk_code int 虚拟按键码
 
 int类型 0成功，1失败
 */
-func (com *opsoft) KeyPress(vk_code int) int {
+func (com *Opsoft) KeyPress(vk_code int) int {
 	ret, _ := com.op.CallMethod("KeyPress", vk_code)
 	return int(ret.Val)
 }
@@ -99,7 +99,7 @@ key_str string 字符串描述的键码. 大小写无所谓.
 
 int类型 0成功，1失败
 */
-func (com *opsoft) KeyPressChar(key_str string) int {
+func (com *Opsoft) KeyPressChar(key_str string) int {
 	ret, _ := com.op.CallMethod("KeyPressChar", key_str)
 	return int(ret.Val)
 }
@@ -115,7 +115,7 @@ vk_code int 虚拟按键码.
 
 int类型 0成功，1失败
 */
-func (com *opsoft) KeyUp(vk_code int) int {
+func (com *Opsoft) KeyUp(vk_code int) int {
 	ret, _ := com.op.CallMethod("KeyUp", vk_code)
 	return int(ret.Val)
 }
@@ -131,7 +131,7 @@ key_str string 字符串描述的键码. 大小写无所谓.
 
 int类型 0成功，1失败
 */
-func (com *opsoft) KeyUpChar(key_str string) int {
+func (com *Opsoft) KeyUpChar(key_str string) int {
 	ret, _ := com.op.CallMethod("KeyUpChar", key_str)
 	return int(ret.Val)
 }
@@ -143,7 +143,7 @@ func (com *opsoft) KeyUpChar(key_str string) int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) LeftClick() int {
+func (com *Opsoft) LeftClick() int {
 	ret, _ := com.op.CallMethod("LeftClick")
 	return int(ret.Val)
 }
@@ -155,7 +155,7 @@ func (com *opsoft) LeftClick() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) LeftDoubleClick() int {
+func (com *Opsoft) LeftDoubleClick() int {
 	ret, _ := com.op.CallMethod("LeftDoubleClick")
 	return int(ret.Val)
 }
@@ -167,7 +167,7 @@ func (com *opsoft) LeftDoubleClick() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) LeftDown() int {
+func (com *Opsoft) LeftDown() int {
 	ret, _ := com.op.CallMethod("LeftDown")
 	return int(ret.Val)
 }
@@ -179,7 +179,7 @@ func (com *opsoft) LeftDown() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) LeftUp() int {
+func (com *Opsoft) LeftUp() int {
 	ret, _ := com.op.CallMethod("LeftUp")
 	return int(ret.Val)
 }
@@ -191,7 +191,7 @@ func (com *opsoft) LeftUp() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) MiddleClick() int {
+func (com *Opsoft) MiddleClick() int {
 	ret, _ := com.op.CallMethod("MiddleClick")
 	return int(ret.Val)
 }
@@ -203,7 +203,7 @@ func (com *opsoft) MiddleClick() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) MiddleDown() int {
+func (com *Opsoft) MiddleDown() int {
 	ret, _ := com.op.CallMethod("MiddleDown")
 	return int(ret.Val)
 }
@@ -215,7 +215,7 @@ func (com *opsoft) MiddleDown() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) MiddleUp() int {
+func (com *Opsoft) MiddleUp() int {
 	ret, _ := com.op.CallMethod("MiddleUp")
 	return int(ret.Val)
 }
@@ -232,7 +232,7 @@ ry int 相对于上次的Y偏移.
 
 int类型 0成功，1失败
 */
-func (com *opsoft) MoveR(rx, ry int) int {
+func (com *Opsoft) MoveR(rx, ry int) int {
 	ret, _ := com.op.CallMethod("MoveR", rx, ry)
 	return int(ret.Val)
 }
@@ -249,7 +249,7 @@ y int Y坐标.
 
 int类型 0成功，1失败
 */
-func (com *opsoft) MoveTo(x, y int) int {
+func (com *Opsoft) MoveTo(x, y int) int {
 	ret, _ := com.op.CallMethod("MoveTo", x, y)
 	return int(ret.Val)
 }
@@ -268,7 +268,7 @@ h int 高度(从y计算起)
 
 string 返回要移动到的目标点. 格式为x,y. 比如MoveToEx 100,100,10,10,返回值可能是101,102
 */
-func (com *opsoft) MoveToEx(x, y, w, h int) string {
+func (com *Opsoft) MoveToEx(x, y, w, h int) string {
 	ret, _ := com.op.CallMethod("MoveToEx", x, y, w, h)
 	return ret.ToString()
 }
@@ -280,7 +280,7 @@ func (com *opsoft) MoveToEx(x, y, w, h int) string {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) RightClick() int {
+func (com *Opsoft) RightClick() int {
 	ret, _ := com.op.CallMethod("RightClick")
 	return int(ret.Val)
 }
@@ -292,7 +292,7 @@ func (com *opsoft) RightClick() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) RightDown() int {
+func (com *Opsoft) RightDown() int {
 	ret, _ := com.op.CallMethod("RightDown")
 	return int(ret.Val)
 }
@@ -304,7 +304,7 @@ func (com *opsoft) RightDown() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) RightUp() int {
+func (com *Opsoft) RightUp() int {
 	ret, _ := com.op.CallMethod("RightUp")
 	return int(ret.Val)
 }
@@ -321,7 +321,7 @@ time_out int 等待多久,单位毫秒. 如果是0，表示一直等待
 
 int类型 0成功，1失败
 */
-func (com *opsoft) WaitKey(vk_code, timeOut int) int {
+func (com *Opsoft) WaitKey(vk_code, timeOut int) int {
 	ret, _ := com.op.CallMethod("SetSimMode", vk_code, timeOut)
 	return int(ret.Val)
 }
@@ -333,7 +333,7 @@ func (com *opsoft) WaitKey(vk_code, timeOut int) int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) WheelDown() int {
+func (com *Opsoft) WheelDown() int {
 	ret, _ := com.op.CallMethod("WheelDown")
 	return int(ret.Val)
 }
@@ -345,7 +345,7 @@ func (com *opsoft) WheelDown() int {
 
 int类型 0成功，1失败
 */
-func (com *opsoft) WheelUp() int {
+func (com *Opsoft) WheelUp() int {
 	ret, _ := com.op.CallMethod("WheelUp")
 	return int(ret.Val)
 }

--- a/load.go
+++ b/load.go
@@ -5,16 +5,16 @@ import (
 	"github.com/go-ole/go-ole/oleutil"
 )
 
-type opsoft struct {
+type Opsoft struct {
 	op *ole.IDispatch
 	uk *ole.IUnknown
 }
 
-func Load() (*opsoft, error) {
+func Load() (*Opsoft, error) {
 	var err error
-	com := new(opsoft)
+	com := new(Opsoft)
 	ole.CoInitialize(0)
-	com.uk, err = oleutil.CreateObject("op.opsoft")
+	com.uk, err = oleutil.CreateObject("op.Opsoft")
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +25,7 @@ func Load() (*opsoft, error) {
 	return com, nil
 }
 
-func (com *opsoft) Release() {
+func (com *Opsoft) Release() {
 	com.uk.Release()
 	com.op.Release()
 	ole.CoUninitialize()

--- a/load.go
+++ b/load.go
@@ -14,7 +14,7 @@ func Load() (*Opsoft, error) {
 	var err error
 	com := new(Opsoft)
 	ole.CoInitialize(0)
-	com.uk, err = oleutil.CreateObject("op.Opsoft")
+	com.uk, err = oleutil.CreateObject("op.opsoft")
 	if err != nil {
 		return nil, err
 	}

--- a/mouse.go
+++ b/mouse.go
@@ -1,21 +1,21 @@
 package op
 
-func (com *opsoft) SetKeypadDelay(types string, delay int) int {
+func (com *Opsoft) SetKeypadDelay(types string, delay int) int {
 	ret, _ := com.op.CallMethod("SetKeypadDelay", types, delay)
 	return int(ret.Val)
 }
 
-func (com *opsoft) SetMouseDelay(types string, delay int) int {
+func (com *Opsoft) SetMouseDelay(types string, delay int) int {
 	ret, _ := com.op.CallMethod("SetMouseDelay", types, delay)
 	return int(ret.Val)
 }
 
-func (com *opsoft) SetMouseSpeed(speed int) int {
+func (com *Opsoft) SetMouseSpeed(speed int) int {
 	ret, _ := com.op.CallMethod("SetMouseSpeed", speed)
 	return int(ret.Val)
 }
 
-func (com *opsoft) SetSimMode(mode int) int {
+func (com *Opsoft) SetSimMode(mode int) int {
 	ret, _ := com.op.CallMethod("SetSimMode", mode)
 	return int(ret.Val)
 }

--- a/ocr.go
+++ b/ocr.go
@@ -35,7 +35,7 @@ intY 变参指针:返回Y坐标没找到返回-1
 
 int 没找到返回-1, 比如"长安|洛阳",若找到长安，则返回0
 */
-func (com *opsoft) FindStr(x1, y1, x2, y2 int, str string, color_format string, sim float32, intX *int, intY *int) int {
+func (com *Opsoft) FindStr(x1, y1, x2, y2 int, str string, color_format string, sim float32, intX *int, intY *int) int {
 	x := ole.NewVariant(ole.VT_I4, 0)
 	y := ole.NewVariant(ole.VT_I4, 0)
 	ret, _ := com.op.CallMethod("FindStr", x1, y1, x2, y2, str, color_format, sim, &x, &y)
@@ -76,7 +76,7 @@ sim 双精度浮点数:相似度,取值范围0.1-1.0
 
 int 没找到返回-1, 比如"长安|洛阳",若找到长安，则返回0
 */
-func (com *opsoft) FindStrEx(x1, y1, x2, y2 int, str, colorFormat string, sim float32) string {
+func (com *Opsoft) FindStrEx(x1, y1, x2, y2 int, str, colorFormat string, sim float32) string {
 	ret, _ := com.op.CallMethod("FindStrEx", x1, y1, x2, y2, str, colorFormat, sim)
 	return ret.ToString()
 }
@@ -108,7 +108,7 @@ int 0成功，1失败
 
 注: 此函数速度很慢，全局初始化时调用一次即可，切换字库用UseDict
 */
-func (com *opsoft) Ocr(x1, y1, x2, y2 int, colorFormat string, sim float32) string {
+func (com *Opsoft) Ocr(x1, y1, x2, y2 int, colorFormat string, sim float32) string {
 	ret, _ := com.op.CallMethod("Ocr", x1, y1, x2, y2, colorFormat, sim)
 	return ret.ToString()
 }
@@ -141,7 +141,7 @@ sim 双精度浮点数:相似度,取值范围0.1-1.0
 字符串: 返回识别到的字符串 格式如 "字符0$x0$y0|…|字符n$xn$yn"
 
 */
-func (com *opsoft) OcrEx(x1, y1, x2, y2 int, colorFormat string, sim float32) string {
+func (com *Opsoft) OcrEx(x1, y1, x2, y2 int, colorFormat string, sim float32) string {
 	ret, _ := com.op.CallMethod("OcrEx", x1, y1, x2, y2, colorFormat, sim)
 	return ret.ToString()
 }
@@ -161,7 +161,7 @@ int 0成功，1失败
 
 注: 此函数速度很慢，全局初始化时调用一次即可，切换字库用UseDict
 */
-func (com *opsoft) SetDict(index int, file string) int {
+func (com *Opsoft) SetDict(index int, file string) int {
 	ret, _ := com.op.CallMethod("SetDict", index, file)
 	return int(ret.Val)
 }
@@ -181,7 +181,7 @@ ndex int 字库编号(0-9)
 
 int 0成功，1失败
 */
-func (com *opsoft) UseDict(index int) int {
+func (com *Opsoft) UseDict(index int) int {
 	ret, _ := com.op.CallMethod("UseDict", index)
 	return int(ret.Val)
 }
@@ -209,7 +209,7 @@ sim float32 相似度,取值范围0.1-1.0
 
 string 返回识别到的字符串
 */
-func (com *opsoft) OcrAuto(x1, y1, x2, y2 int, sim float32) string {
+func (com *Opsoft) OcrAuto(x1, y1, x2, y2 int, sim float32) string {
 	ret, _ := com.op.CallMethod("OcrAuto", x1, y1, x2, y2, sim)
 	return ret.ToString()
 }
@@ -233,7 +233,7 @@ sim float32 相似度,取值范围0.1-1.0
 
 string 返回识别到的字符串
 */
-func (com *opsoft) OcrFromFile(file_name, color_format string, sim float32) string {
+func (com *Opsoft) OcrFromFile(file_name, color_format string, sim float32) string {
 	ret, _ := com.op.CallMethod("OcrFromFile", file_name, color_format, sim)
 	return ret.ToString()
 }
@@ -255,7 +255,7 @@ sim float32 相似度,取值范围0.1-1.0
 
 string 返回识别到的字符串
 */
-func (com *opsoft) OcrAutoFromFile(color_format string, sim float32) string {
+func (com *Opsoft) OcrAutoFromFile(color_format string, sim float32) string {
 	ret, _ := com.op.CallMethod("OcrAutoFromFile", color_format, sim)
 	return ret.ToString()
 }

--- a/tools.go
+++ b/tools.go
@@ -25,7 +25,7 @@ endY 整形数:目的坐标Y
 
 int 0 失败，1 成功
 */
-func (com *opsoft) AStarFindPath(mapWidth, mapHeight int, disable_points string, beginX, beginY, endX, endY int) int {
+func (com *Opsoft) AStarFindPath(mapWidth, mapHeight int, disable_points string, beginX, beginY, endX, endY int) int {
 	ret, _ := com.op.CallMethod("AStarFindPath", mapWidth, mapHeight, disable_points, beginX, beginY, endX, endY)
 	return int(ret.Val)
 }

--- a/winapi.go
+++ b/winapi.go
@@ -13,7 +13,7 @@ mode int类型 模式 0普通模式，1加强模式
 
 int类型 0失败，1成功
 */
-func (com *opsoft) RunApp(path string, mode int) int {
+func (com *Opsoft) RunApp(path string, mode int) int {
 	ret, _ := com.op.CallMethod("RunApp", path, mode)
 	return int(ret.Val)
 }
@@ -31,7 +31,7 @@ dis int类型 模式 0隐藏，1用最近的大小和位置显示,
 
 int类型 0失败，1成功
 */
-func (com *opsoft) WinExec(path string, dis int) int {
+func (com *Opsoft) WinExec(path string, dis int) int {
 	ret, _ := com.op.CallMethod("WinExec", path, dis)
 	return int(ret.Val)
 }
@@ -49,7 +49,7 @@ time int类型 等待时间 毫秒
 
 string类型 cmd输出的字符
 */
-func (com *opsoft) GetCmdStr(path string, time int) string {
+func (com *Opsoft) GetCmdStr(path string, time int) string {
 	ret, _ := com.op.CallMethod("GetCmdStr", path, time)
 	return ret.ToString()
 }

--- a/window.go
+++ b/window.go
@@ -17,7 +17,7 @@ y 变参指针: 窗口Y坐标
 
 int 0 失败，1 成功
 */
-func (com *opsoft) ClientToScreen(hwnd int, x, y *int) int {
+func (com *Opsoft) ClientToScreen(hwnd int, x, y *int) int {
 	intx := ole.NewVariant(ole.VT_I4, int64(*x))
 	inty := ole.NewVariant(ole.VT_I4, int64(*y))
 	ret, _ := com.op.CallMethod("ClientToScreen", hwnd, &intx, &inty)
@@ -41,7 +41,7 @@ name 字符串:进程名,比如qq.exe
 
 字符串 : 返回所有匹配的进程PID,并按打开顺序排序,格式"pid1,pid2,pid3"
 */
-func (com *opsoft) EnumProcess(name string) string {
+func (com *Opsoft) EnumProcess(name string) string {
 	ret, _ := com.op.CallMethod("EnumProcess", name)
 	return ret.ToString()
 }
@@ -79,7 +79,7 @@ filter整形数: 取值定义如下
 
 字符串 : 返回所有匹配的窗口句柄字符串,格式"hwnd1,hwnd2,hwnd3"
 */
-func (com *opsoft) EnumWindow(parent int, title, className string, filter int) string {
+func (com *Opsoft) EnumWindow(parent int, title, className string, filter int) string {
 	ret, _ := com.op.CallMethod("EnumWindow", parent, title, className, filter)
 	return ret.ToString()
 }
@@ -113,7 +113,7 @@ filter 整形数: 取值定义如下
 
 字符串: 返回所有匹配的窗口句柄字符串,格式"hwnd1,hwnd2,hwnd3"
 */
-func (com *opsoft) EnumWindowByProcessId(pid int, title, className string, filter int) string {
+func (com *Opsoft) EnumWindowByProcessId(pid int, title, className string, filter int) string {
 	ret, _ := com.op.CallMethod("EnumWindowByProcessId", pid, title, className, filter)
 	return ret.ToString()
 }
@@ -195,7 +195,7 @@ sort 整形数: 取值如下
 
 字符串: 返回所有匹配的窗口句柄字符串,格式"hwnd1,hwnd2,hwnd3"
 */
-func (com *opsoft) EnumWindowSuper(spec1 string, flag1, type1 int, spec2 string, flag2, type2, sort int) string {
+func (com *Opsoft) EnumWindowSuper(spec1 string, flag1, type1 int, spec2 string, flag2, type2, sort int) string {
 	ret, _ := com.op.CallMethod("EnumWindowSuper", spec1, flag1, type1, spec2, flag2, type2, sort)
 	return ret.ToString()
 }
@@ -215,7 +215,7 @@ title 字符串: 窗口标题,如果为空，则匹配所有.这里的匹配是�
 
 整形数: 整形数表示的窗口句柄，没找到返回0.
 */
-func (com *opsoft) FindWindow(class, title string) int {
+func (com *Opsoft) FindWindow(class, title string) int {
 	ret, _ := com.op.CallMethod("FindWindow", class, title)
 	return int(ret.Val)
 }
@@ -237,7 +237,7 @@ title 字符串: 窗口标题,如果为空，则匹配所有.这里的匹配是�
 
 整形数: 整形数表示的窗口句柄，没找到返回0.
 */
-func (com *opsoft) FindWindowByProcess(processName, class, title string) int {
+func (com *Opsoft) FindWindowByProcess(processName, class, title string) int {
 	ret, _ := com.op.CallMethod("FindWindowByProcess", processName, class, title)
 	return int(ret.Val)
 }
@@ -259,7 +259,7 @@ title 字符串: 窗口标题,如果为空，则匹配所有.这里的匹配是�
 
 整形数: 整形数表示的窗口句柄，没找到返回0.
 */
-func (com *opsoft) FindWindowByProcessId(processId int, class, title string) int {
+func (com *Opsoft) FindWindowByProcessId(processId int, class, title string) int {
 	ret, _ := com.op.CallMethod("FindWindowByProcessId", processId, class, title)
 	return int(ret.Val)
 }
@@ -281,7 +281,7 @@ title 字符串: 窗口标题,如果为空，则匹配所有. 这里的匹配是
 
 整形数: 整形数表示的窗口句柄，没找到返回0.
 */
-func (com *opsoft) FindWindowEx(parent int, class, title string) int {
+func (com *Opsoft) FindWindowEx(parent int, class, title string) int {
 	ret, _ := com.op.CallMethod("FindWindowEx", parent, class, title)
 	return int(ret.Val)
 }
@@ -357,7 +357,7 @@ type2 整形数: 取值如下
 
 整形数: 整形数表示的窗口句柄，没找到返回0
 */
-func (com *opsoft) FindWindowSuper(spec1 string, flag1, type1 int, spec2 string, flag2, type2 int) int {
+func (com *Opsoft) FindWindowSuper(spec1 string, flag1, type1 int, spec2 string, flag2, type2 int) int {
 	ret, _ := com.op.CallMethod("FindWindowSuper", spec1, flag1, type1, spec2, flag2, type2)
 	return int(ret.Val)
 }
@@ -383,7 +383,7 @@ y2 变参指针: 返回窗口客户区右下角Y坐标
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) GetClientRect(hwnd int, x1, y1, x2, y2 *int) int {
+func (com *Opsoft) GetClientRect(hwnd int, x1, y1, x2, y2 *int) int {
 	intx1 := ole.NewVariant(ole.VT_I4, int64(*x1))
 	inty1 := ole.NewVariant(ole.VT_I4, int64(*y1))
 	intx2 := ole.NewVariant(ole.VT_I4, int64(*x2))
@@ -417,7 +417,7 @@ height 变参指针: 高度
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) GetClientSize(hwnd int, width, height *int) int {
+func (com *Opsoft) GetClientSize(hwnd int, width, height *int) int {
 	pWidth := ole.NewVariant(ole.VT_I4, int64(*width))
 	pHeight := ole.NewVariant(ole.VT_I4, int64(*height))
 	ret, _ := com.op.CallMethod("GetClientSize", hwnd, &pWidth, &pHeight)
@@ -437,7 +437,7 @@ func (com *opsoft) GetClientSize(hwnd int, width, height *int) int {
 
 整形数: 返回整型表示的窗口句柄
 */
-func (com *opsoft) GetForegroundFocus() int {
+func (com *Opsoft) GetForegroundFocus() int {
 	ret, _ := com.op.CallMethod("GetForegroundFocus")
 	return int(ret.Val)
 }
@@ -451,7 +451,7 @@ func (com *opsoft) GetForegroundFocus() int {
 
 整形数: 返回整型表示的窗口句柄
 */
-func (com *opsoft) GetForegroundWindow() int {
+func (com *Opsoft) GetForegroundWindow() int {
 	ret, _ := com.op.CallMethod("GetForegroundWindow")
 	return int(ret.Val)
 }
@@ -465,7 +465,7 @@ func (com *opsoft) GetForegroundWindow() int {
 
 整形数: 返回整型表示的窗口句柄
 */
-func (com *opsoft) GetMousePointWindow() int {
+func (com *Opsoft) GetMousePointWindow() int {
 	ret, _ := com.op.CallMethod("GetMousePointWindow")
 	return int(ret.Val)
 }
@@ -485,7 +485,7 @@ Y 整形数: 屏幕Y坐标.
 
 整形数: 返回整型表示的窗口句柄.
 */
-func (com *opsoft) GetPointWindow(x, y int) int {
+func (com *Opsoft) GetPointWindow(x, y int) int {
 	ret, _ := com.op.CallMethod("GetPointWindow", x, y)
 	return int(ret.Val)
 }
@@ -503,7 +503,7 @@ pid 整形数: 进程pid.
 
 字符串: 格式"进程名|进程路径|cpu|内存"
 */
-func (com *opsoft) GetProcessInfo(pid int) string {
+func (com *Opsoft) GetProcessInfo(pid int) string {
 	ret, _ := com.op.CallMethod("GetProcessInfo", pid)
 	return ret.ToString()
 }
@@ -525,7 +525,7 @@ Flag 整形数: 取值定义如下
 
 整形数: 以整型数表示的窗口句柄
 */
-func (com *opsoft) GetSpecialWindow(flag int) int {
+func (com *Opsoft) GetSpecialWindow(flag int) int {
 	ret, _ := com.op.CallMethod("GetSpecialWindow", flag)
 	return int(ret.Val)
 }
@@ -543,7 +543,7 @@ hwnd 整形数: 指定的窗口句柄
 
 字符串: 窗口的类名
 */
-func (com *opsoft) GetWindowClass(hwnd int) string {
+func (com *Opsoft) GetWindowClass(hwnd int) string {
 	ret, _ := com.op.CallMethod("GetWindowClass", hwnd)
 	return ret.ToString()
 }
@@ -561,7 +561,7 @@ hwnd 整形数: 窗口句柄
 
 整形数: 返回整型表示的是进程ID
 */
-func (com *opsoft) GetWindowProcessId(hwnd int) int {
+func (com *Opsoft) GetWindowProcessId(hwnd int) int {
 	ret, _ := com.op.CallMethod("GetWindowProcessId", hwnd)
 	return int(ret.Val)
 }
@@ -579,7 +579,7 @@ hwnd 整形数: 窗口句柄
 
 字符串: 返回字符串表示的是exe全路径名
 */
-func (com *opsoft) GetWindowProcessPath(hwnd int) string {
+func (com *Opsoft) GetWindowProcessPath(hwnd int) string {
 	ret, _ := com.op.CallMethod("GetWindowProcessPath", hwnd)
 	return ret.ToString()
 }
@@ -605,7 +605,7 @@ y2 变参指针: 返回窗口右下角Y坐标
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) GetWindowRect(hwnd int, x1, y1, x2, y2 *int) int {
+func (com *Opsoft) GetWindowRect(hwnd int, x1, y1, x2, y2 *int) int {
 	intx1 := ole.NewVariant(ole.VT_I4, int64(*x1))
 	inty1 := ole.NewVariant(ole.VT_I4, int64(*y1))
 	intx2 := ole.NewVariant(ole.VT_I4, int64(*x2))
@@ -655,7 +655,7 @@ flag 整形数: 取值定义如下
 
 整形数: 0: 不满足条件 1: 满足条件
 */
-func (com *opsoft) GetWindowState(hwnd, flag int) int {
+func (com *Opsoft) GetWindowState(hwnd, flag int) int {
 	ret, _ := com.op.CallMethod("GetWindowState", hwnd, flag)
 	return int(ret.Val)
 }
@@ -673,7 +673,7 @@ hwnd 整形数: 指定的窗口句柄
 
 字符串: 窗口的标题
 */
-func (com *opsoft) GetWindowTitle(hwnd int) string {
+func (com *Opsoft) GetWindowTitle(hwnd int) string {
 	ret, _ := com.op.CallMethod("GetWindowTitle", hwnd)
 	return ret.ToString()
 }
@@ -695,7 +695,7 @@ y 整形数: Y坐标
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) MoveWindow(hwnd, x, y int) int {
+func (com *Opsoft) MoveWindow(hwnd, x, y int) int {
 	ret, _ := com.op.CallMethod("MoveWindow", hwnd, x, y)
 	return int(ret.Val)
 }
@@ -717,7 +717,7 @@ y 变参指针: 屏幕Y坐标
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) ScreenToClient(hwnd int, x, y *int) int {
+func (com *Opsoft) ScreenToClient(hwnd int, x, y *int) int {
 	intx := ole.NewVariant(ole.VT_I4, int64(*x))
 	inty := ole.NewVariant(ole.VT_I4, int64(*y))
 	ret, _ := com.op.CallMethod("ScreenToClient", hwnd, &intx, &inty)
@@ -743,7 +743,7 @@ hwnd 整形数: 指定的窗口句柄
 
 注:剪贴板是公共资源，多个线程同时设置剪贴板时,会产生冲突，必须用互斥信号保护.
 */
-func (com *opsoft) SendPaste(hwnd int) int {
+func (com *Opsoft) SendPaste(hwnd int) int {
 	ret, _ := com.op.CallMethod("SendPaste", hwnd)
 	return int(ret.Val)
 }
@@ -769,7 +769,7 @@ str 字符串: 发送的文本数据
 
 目标程序里可能安装了改变当前编码的软件，比如常见的是输入法. （尝试卸载）
 */
-func (com *opsoft) SendString(hwnd int, str string) int {
+func (com *Opsoft) SendString(hwnd int, str string) int {
 	ret, _ := com.op.CallMethod("SendString", hwnd, str)
 	return int(ret.Val)
 }
@@ -791,7 +791,7 @@ height 整形数: 高度
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) SetClientSize(hwnd, width, height int) int {
+func (com *Opsoft) SetClientSize(hwnd, width, height int) int {
 	ret, _ := com.op.CallMethod("SetClientSize", hwnd, width, height)
 	return int(ret.Val)
 }
@@ -813,7 +813,7 @@ height 整形数: 高度
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) SetWindowSize(hwnd, width, height int) int {
+func (com *Opsoft) SetWindowSize(hwnd, width, height int) int {
 	ret, _ := com.op.CallMethod("SetWindowSize", hwnd, width, height)
 	return int(ret.Val)
 }
@@ -865,7 +865,7 @@ flag 整形数: 取值定义如下
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) SetWindowState(hwnd, flag int) int {
+func (com *Opsoft) SetWindowState(hwnd, flag int) int {
 	ret, _ := com.op.CallMethod("SetWindowState", hwnd, flag)
 	return int(ret.Val)
 }
@@ -885,7 +885,7 @@ titie 字符串: 标题
 
 整形数: 0: 失败 1: 成功
 */
-func (com *opsoft) SetWindowText(hwnd int, title string) int {
+func (com *Opsoft) SetWindowText(hwnd int, title string) int {
 	ret, _ := com.op.CallMethod("SetWindowText", hwnd, title)
 	return int(ret.Val)
 }
@@ -907,7 +907,7 @@ trans 整形数: 透明度取值(0-255) 越小透明度越大 0为完全透明(�
 
 注 : 此接口不支持WIN98
 */
-func (com *opsoft) SetWindowTransparent(hwnd, trans int) int {
+func (com *Opsoft) SetWindowTransparent(hwnd, trans int) int {
 	ret, _ := com.op.CallMethod("SetWindowTransparent", hwnd, trans)
 	return int(ret.Val)
 }


### PR DESCRIPTION
如果其他人要使用这个库，会因为无法访问op对象而无法进行传递，不便于开发